### PR TITLE
add setCrossOrigin for ObjLoader

### DIFF
--- a/index.js
+++ b/index.js
@@ -941,7 +941,9 @@ THREE.OBJLoader = ( function () {
 			var scope = this;
 
 			var loader = new THREE.FileLoader( scope.manager );
-			loader.setPath( this.path );
+      loader.setPath( this.path );
+      if ( this.setCrossOrigin ) loader.setWithCredentials( this.crossOrigin );
+    
 			loader.load( url, function ( text ) {
 
 				onLoad( scope.parse( text ) );
@@ -964,7 +966,14 @@ THREE.OBJLoader = ( function () {
 
 			return this;
 
-		},
+    },
+    
+    setCrossOrigin: function ( value ) {
+
+      this.crossOrigin = value;
+      return this;
+  
+    },
 
 		parse: function ( text ) {
 


### PR DESCRIPTION
Because I was in need for it ;)

This PR implements the following functionality.

Example:
```javascript
const loader = new OBJLoader();
loader.setCrossOrigin('use-credentials');
...
```