### PR TITLE
Fix loading textures (THREE.Loader: Handlers.get() has been removed. )

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,10 +540,10 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 	loadTexture: function ( url, mapping, onLoad, onProgress, onError ) {
 
 		var texture;
-		var loader = THREE.Loader.Handlers.get( url );
+		let loader = new THREE.LoadingManager().getHandler( url )
 		var manager = ( this.manager !== undefined ) ? this.manager : THREE.DefaultLoadingManager;
 
-		if ( loader === null ) {
+		if (!loader) {
 
 			loader = new THREE.TextureLoader( manager );
 


### PR DESCRIPTION
Current texture loading is not working.

I have fixed it by using the up-to-date method of three.js.

Fix 'THREE.Loader: Handlers.get() has been removed. Use LoadingManager.getHandler() instead.'