### PR TITLE
Handlers.get() has been removed. Use

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,9 +540,11 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 	loadTexture: function ( url, mapping, onLoad, onProgress, onError ) {
 
 		var texture;
-		var loader = THREE.Loader.Handlers.get( url );
+		
 		var manager = ( this.manager !== undefined ) ? this.manager : THREE.DefaultLoadingManager;
 
+		var loader = manager.getHandler(url);
+		
 		if ( loader === null ) {
 
 			loader = new THREE.TextureLoader( manager );


### PR DESCRIPTION
Handlers.get() has been removed .use manager.getHandler(url)